### PR TITLE
Fix typo in blog post

### DIFF
--- a/posts/39-product-updates-and-new-features-2019-q4.md
+++ b/posts/39-product-updates-and-new-features-2019-q4.md
@@ -33,7 +33,7 @@ Enable anonymous team dashboards from your [dashboard settings][dashboards] page
 
 <br>
 
-⌛ **Total time logged in a project** - on a [project’s dashboard][projects] dashboard, see the total time you’ve logged to a project since the day you started using WakaTime.
+⌛ **Total time logged in a project** - on a [project’s dashboard][projects], see the total time you’ve logged to a project since the day you started using WakaTime.
 
 <img src="https://wakatime.com/static/img/blog/project-total-all-time.gif" class="img-thumbnail" alt="project total feature" style="width:80%" />
 


### PR DESCRIPTION
There was a typo in the most recent blog post, the word `dashboard` was used twice in a row.

PS Love the link to "edit on github"! 