### PR TITLE
Fix mutable arg in BaseModel.to_dict example

### DIFF
--- a/posts/32-flask-part-1-sqlalchemy-models-as-json.md
+++ b/posts/32-flask-part-1-sqlalchemy-models-as-json.md
@@ -37,10 +37,11 @@ db = SQLAlchemy(app)
 class BaseModel(db.Model):
     __abstract__ = True
 
-    def to_dict(self, show=None, _hide=[], _path=None):
+    def to_dict(self, show=None, _hide=None, _path=None):
         """Return a dictionary representation of this model."""
 
         show = show or []
+        _hide = _hide or []
 
         hidden = self._hidden_fields if hasattr(self, "_hidden_fields") else []
         default = self._default_fields if hasattr(self, "_default_fields") else []


### PR DESCRIPTION
With multiple calls to `to_dict` with models containing child relationships the `_hide` argument will mutate which will cause the child properties to be omitted from results beyond the first call.

See https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments